### PR TITLE
Use Compat to fix UTF8String deprecation warning

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.4
 
 MacroTools
 Requests
-Compat
+Compat 0.7.16

--- a/src/Currencies.jl
+++ b/src/Currencies.jl
@@ -3,6 +3,7 @@ module Currencies
 using MacroTools
 using Requests
 using Compat
+import Compat.String
 
 import Base: +, -, *, /, ==
 
@@ -15,8 +16,6 @@ export Basket, StaticBasket, DynamicBasket
 export simplefv, compoundfv
 export newcurrency!, @usingcustomcurrency
 export format
-
-const String = VERSION ≥ v"0.5-" ? Base.String : UTF8String
 
 # Currency data
 include("data/currencies.jl")


### PR DESCRIPTION
It would be good to tag a new release as soon as possible to make user experience better for those testing on nightlies.
