### PR TITLE
Remove dependency on MacroTools

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.4
 
-MacroTools
 Requests
 Compat 0.7.16

--- a/src/Currencies.jl
+++ b/src/Currencies.jl
@@ -1,6 +1,5 @@
 module Currencies
 
-using MacroTools
 using Requests
 using Compat
 import Compat.String

--- a/src/usingcurrencies.jl
+++ b/src/usingcurrencies.jl
@@ -13,10 +13,10 @@ does not work for those. Instead, define them manually:
     const XAU = Monetary(:XAU; precision=4)
 """
 macro usingcurrencies(curs)
-    if isexpr(curs, Symbol)
+    if isa(curs, Symbol)
         curs = Expr(:tuple, curs)
     end
-    @assert isexpr(curs, :tuple)
+    @assert Meta.isexpr(curs, :tuple)
 
     quote
         $([:(const $cur = Monetary($(Expr(:quote, cur))))


### PR DESCRIPTION
The use of this package was incredibly limited; we can use `Base.Meta` instead. This brings us closer to precompilation too.
