### PR TITLE
Fix typo preventing docs deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,6 @@ deploydocs(
             "pygments",
             "mkdocs",
             "mkdocs-material",
-            "python-markdown-math")
+            "python-markdown-math"),
     repo = "github.com/TotalVerb/Currencies.jl.git"
 )


### PR DESCRIPTION
There was a major typo that prevented the docs from deploying.
