### PR TITLE
Remove the IOContext multilang attribute

### DIFF
--- a/src/CurrenciesCompat/CurrenciesCompat.jl
+++ b/src/CurrenciesCompat/CurrenciesCompat.jl
@@ -23,8 +23,7 @@ end
 
 # Provide writemime ⇒ show fallback
 if VERSION < v"0.5.0-dev+4356"
-    verbose_show(io, m, x) =
-            show(IOContext(io, multiline=true, limit=false), m, x)
+    verbose_show(io, m, x) = show(IOContext(io, limit=false), m, x)
     Base.show(x::IO, y::AbstractString, z) = show(x, MIME(y), z)
     Base.writemime(x::IO, y, z) = show(x, y, z)
 


### PR DESCRIPTION
This removes the dependence on the removed `:multilang` IOContext attribute.
