### PR TITLE
Fix functionality broken by 0.6 subtyping changes

### DIFF
--- a/src/CurrenciesBase/CurrenciesBase.jl
+++ b/src/CurrenciesBase/CurrenciesBase.jl
@@ -1,5 +1,6 @@
 module CurrenciesBase
 
+import ..Currencies
 using ..CurrencyData
 
 import Base: +, -, *, /, ==

--- a/src/CurrenciesBase/arithmetic.jl
+++ b/src/CurrenciesBase/arithmetic.jl
@@ -23,16 +23,16 @@ Base.one{T<:AbstractMonetary}(::T) = one(T)
 =={T<:Monetary}(m::T, n::T) = m.val == n.val
 =={T}(m::Monetary{T}, n::Monetary{T}) = (m - n).val == 0
 m::Monetary == n::Monetary = m.val == n.val == 0
-Base.isless{T<:Monetary}(m::T, n::T) = isless(m.val, n.val)
+Base.isless{T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) = isless(m.val, n.val)
 
 # unary plus/minus
 + m::AbstractMonetary = m
 -{T<:Monetary}(m::T) = T(-m.val)
 
 # arithmetic operations on two monetary values
-+{T<:Monetary}(m::T, n::T) = T(m.val + n.val)
--{T<:Monetary}(m::T, n::T) = T(m.val - n.val)
-/{T<:Monetary}(m::T, n::T) = m.val / n.val
++{T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) = Monetary{T,U,V}(m.val + n.val)
+-{T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) = Monetary{T,U,V}(m.val - n.val)
+/{T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) = m.val / n.val
 
 # arithmetic operations on monetary and dimensionless values
 *{T<:Monetary}(m::T, i::Integer) = T(m.val * i)
@@ -57,7 +57,8 @@ for (dv, rm, dvrm) in DIVS
         quotient, remainder = $(dvrm)(m.val, n.val)
         quotient, Monetary{T,U,V}(remainder)
     end
-    @eval Base.$(dv){T<:Monetary}(m::T, n::T) = $(dv)(m.val, n.val)
+    @eval Base.$(dv){T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) =
+        $(dv)(m.val, n.val)
     @eval Base.$(rm){T,U,V}(m::Monetary{T,U,V}, n::Monetary{T,U,V}) =
         Monetary{T,U,V}($(rm)(m.val, n.val))
 end

--- a/src/CurrenciesBase/currency.jl
+++ b/src/CurrenciesBase/currency.jl
@@ -5,10 +5,16 @@ macro flexible(assignment)
     @assert assignment.head == :(=)
     symb = assignment.args[1].args[1]
     quote
-        $assignment
-        $symb{U<:Monetary}(::Type{U}) = $symb(U.parameters[1])
-        $symb(m::Monetary) = $symb(typeof(m))
-    end |> esc
+        $(esc(assignment))
+        if VERSION < v"0.6.0-dev.2123"
+            $(esc(symb)){U<:Monetary}(::Type{U}) = $(esc(symb))(U.parameters[1])
+        else
+            include_string("""
+            $($(esc(symb)))(::Type{U}) where U <: Monetary{S} where S = $($(esc(symb)))(S)
+            """)
+        end
+        $(esc(symb))(m::Monetary) = $(esc(symb))(typeof(m))
+    end
 end
 
 """


### PR DESCRIPTION
This fixes the functionality broken by 0.6 subtyping and macro hygiene changes, such that the package core functionality no longer freezes Julia. (<s>It is possible that the breakage is due to a Julia bug, see https://github.com/JuliaLang/julia/issues/20130, but this can be worked around.</s> This breakage is actually due to fixing behaviour that was incorrect before, and Currencies was depending on.) Tests are still failing but for unrelated reasons.

Fixes #63 

cc @tkelman
Since this issue is causing problems with PackageEvaluator, I will merge and tag in 24 hours if there are no objections.