### PR TITLE
Adding crypto as subpackage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Manifest.toml
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/src/Crypto.jl
+++ b/src/Crypto.jl
@@ -1,0 +1,37 @@
+module Crypto
+
+using DelimitedFiles
+
+import Currencies: unit, name
+
+export CryptoCurrency
+
+const (data,headers) = readdlm(joinpath(@__DIR__,"data","crypto.csv"),',',header=true)
+
+struct CryptoCurrency{T}
+    function CryptoCurrency{T}() where T
+        c = new()
+        list[T] = c
+        return c
+    end
+end
+const list = Dict{Symbol,CryptoCurrency}()
+
+const (nrow,ncol) = size(data)
+for i in 1:nrow
+    currencies = split(data[i,1],",")
+    currency_units = split(string(data[i,2]),",")
+    currency_names = split(data[i,3],",")
+    for (currency,currency_unit,currency_name) in zip(currencies,currency_units,currency_names)
+        if (length(currency) >= 3 && length(currency) <= 8) & !isdefined(CryptoCurrency,Symbol(currency))
+            @eval Crypto begin
+                $(Symbol(currency)) = CryptoCurrency{Symbol($(currency))}()
+                unit(::CryptoCurrency{Symbol($(currency))}) = parse(Int,$(currency_unit))
+                name(::CryptoCurrency{Symbol($(currency))}) = $(currency_name)
+                Base.show(io::Base.IO,::CryptoCurrency{Symbol($(currency))}) = print(io,$(currency))
+            end
+        end
+    end
+end
+
+end  # module Crypto

--- a/src/Currencies.jl
+++ b/src/Currencies.jl
@@ -9,7 +9,7 @@ export Currency
 
 const (data,headers) = readdlm(joinpath(@__DIR__,"data","country-codes.csv"),',',header=true)
 
-struct Currency{T} 
+struct Currency{T}
     function Currency{T}() where T
         c = new()
         list[T] = c
@@ -36,5 +36,7 @@ for i in 1:nrow
         end
     end
 end
+
+include("Crypto.jl")
 
 end

--- a/src/data/crypto.csv
+++ b/src/data/crypto.csv
@@ -1,0 +1,11 @@
+alphabetic_code,minor_unit,name
+,,
+BTC,8,Bitcoin
+DCR,8,Decred
+ETH,8,Ethereum
+LTC,8,Litecoin
+USDC,8,USD Coin
+USDT,8,Thether
+XMR,8,Monero
+XRP,8,XRP
+ZEC,8,Zcash

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Currencies
 import Currencies: unit, name, code, USD, PHP, HKD, SGD
+import Currencies.Crypto: BTC, LTC, XMR
 
 using Test
 
@@ -8,8 +9,11 @@ units = [2,2,2,2]
 names = ["US Dollar","Philippine Piso","Hong Kong Dollar","Singapore Dollar"]
 codes = [840,608,344,702]
 
-for (ccy,u,n,c) in zip(currencies,units,names,codes)
+currencies = [BTC,LTC,XMR]
+units = [8,8,8]
+names = ["Bitcoin","Litecoin","Monero"]
+
+for (ccy,u,n) in zip(currencies,units,names)
     @test unit(ccy) == u
     @test name(ccy) == n
-    @test code(ccy) == c
 end


### PR DESCRIPTION
As quickly discussed on [JuliaFinance Roadmap](https://github.com/JuliaFinance/Roadmap/issues/5), please see my code proposal for adding Crypto as a sub package of `Currencies.jl`

There is a lot of duplication still, and I'm sure this draft code can be greatly improved.

The Crypto csv file is quite limited as well and will grow as needs arises. I was also thinking at adding extra columns with crypto constants such as supply limit...